### PR TITLE
mp3-sorter: add ESLint, path-traversal hardening, dialog dedup

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -21,8 +21,19 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    # Project rules on top of flutter_lints. These match the existing style
+    # (single quotes, heavy use of const) and surface real issues without
+    # changing behaviour. Run `flutter analyze` (and `dart fix --apply`) locally
+    # after enabling, as Flutter/Dart is not part of the CI/web environment.
+    prefer_single_quotes: true
+    prefer_const_constructors: true
+    prefer_const_constructors_in_immutables: true
+    prefer_const_declarations: true
+    prefer_final_locals: true
+    avoid_print: true
+    unnecessary_this: true
+    directives_ordering: true
+    sort_child_properties_last: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/app/lib/home_page.dart
+++ b/app/lib/home_page.dart
@@ -6,6 +6,9 @@ import 'haptics.dart';
 import 'list_page.dart';
 import 'settings_page.dart';
 import 'soundboard_controller.dart';
+import 'widgets/keep_alive.dart';
+import 'widgets/key_title.dart';
+import 'widgets/play_pulse.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -43,80 +46,6 @@ class _HomePageState extends State<HomePage> {
   void _haptic(VoidCallback action) {
     Haptics.light();
     action();
-  }
-
-  // Wrap a title for a key tile: max 12 chars per line, break only *before* a
-  // non-lowercase character, max 3 lines, then cut off with an ellipsis.
-  static String _wrapKeyTitle(String s) {
-    bool isLower(String ch) {
-      final c = ch.codeUnitAt(0);
-      return (c >= 0x61 && c <= 0x7a) || 'äöüß'.contains(ch);
-    }
-
-    // Split into chunks; each chunk starts at a break-allowed position
-    // (start of string or any non-lowercase character).
-    final chunks = <String>[];
-    final buf = StringBuffer();
-    for (int i = 0; i < s.length; i++) {
-      final ch = s[i];
-      if (i > 0 && !isLower(ch)) {
-        chunks.add(buf.toString());
-        buf.clear();
-      }
-      buf.write(ch);
-    }
-    if (buf.isNotEmpty) chunks.add(buf.toString());
-
-    final lines = <String>[];
-    String cur = '';
-    bool more = false; // content left over after 3 lines
-    void pushCur() {
-      if (cur.isNotEmpty) {
-        lines.add(cur);
-        cur = '';
-      }
-    }
-
-    outer:
-    for (var chunk in chunks) {
-      // Hard-split a chunk that is itself longer than 12 (all lowercase run).
-      while (chunk.length > 12) {
-        pushCur();
-        if (lines.length >= 3) {
-          more = true;
-          break outer;
-        }
-        lines.add(chunk.substring(0, 12));
-        chunk = chunk.substring(12);
-      }
-      if (chunk.isEmpty) continue;
-      if (cur.isEmpty) {
-        cur = chunk;
-      } else if (cur.length < 6 && cur.length + chunk.length <= 12) {
-        // Only keep merging while the line is still short; once it reaches ~6
-        // characters, break at the next opportunity (shorter, tidier lines).
-        cur += chunk;
-      } else {
-        if (lines.length >= 3) {
-          more = true;
-          break outer;
-        }
-        lines.add(cur);
-        cur = chunk;
-      }
-    }
-    if (!more && cur.isNotEmpty) {
-      if (lines.length < 3) {
-        lines.add(cur);
-      } else {
-        more = true;
-      }
-    }
-    if (more && lines.length == 3) {
-      final last = lines[2];
-      lines[2] = '${last.length >= 12 ? last.substring(0, 11) : last}…';
-    }
-    return lines.join('\n');
   }
 
   // Shown when the user taps a sound while not connected (otherwise nothing
@@ -275,8 +204,8 @@ class _HomePageState extends State<HomePage> {
                 // Keep both tabs alive so switching away and back doesn't reset
                 // the swipe page (bank) or the list scroll/search.
                 children: [
-                  _KeepAlive(child: _tastenTab(connected)),
-                  _KeepAlive(child: _listeTab(connected)),
+                  KeepAlive(child: _tastenTab(connected)),
+                  KeepAlive(child: _listeTab(connected)),
                 ],
               ),
             ),
@@ -388,7 +317,7 @@ class _HomePageState extends State<HomePage> {
                       itemBuilder: (context, i) {
                         final t = filtered[i];
                         final playing = controller.playingTrack == t.n;
-                        return _PlayPulse(
+                        return PlayPulse(
                           active: playing,
                           radius: BorderRadius.circular(6),
                           child: ListTile(
@@ -667,7 +596,7 @@ class _HomePageState extends State<HomePage> {
 
   Widget _extraTile(TrackEntry t, bool connected) {
     final playing = controller.playingTrack == t.n;
-    return _PlayPulse(
+    return PlayPulse(
       active: playing,
       radius: BorderRadius.circular(10),
       child: Material(
@@ -693,7 +622,7 @@ class _HomePageState extends State<HomePage> {
                   child: Center(
                     child: FittedBox(
                       fit: BoxFit.scaleDown,
-                      child: Text(_wrapKeyTitle(t.title),
+                      child: Text(wrapKeyTitle(t.title),
                           textAlign: TextAlign.center,
                           maxLines: 3,
                           style: const TextStyle(
@@ -724,7 +653,7 @@ class _HomePageState extends State<HomePage> {
       // The hardware Mode key has no app function – use it for "play a random
       // tone" instead. While a random track is playing, flash its number here.
       final playing = controller.playingFromRandom && controller.playingTrack != null;
-      return _PlayPulse(
+      return PlayPulse(
         active: playing,
         radius: BorderRadius.circular(10),
         child: Material(
@@ -777,7 +706,7 @@ class _HomePageState extends State<HomePage> {
     final playing = controller.playingTrack == track;
     final title =
         AppSettings.instance.showTitlesOnKeys ? controller.titleOf(track) : null;
-    return _PlayPulse(
+    return PlayPulse(
       active: playing,
       radius: BorderRadius.circular(10),
       child: Material(
@@ -805,7 +734,7 @@ class _HomePageState extends State<HomePage> {
                         child: Center(
                           child: FittedBox(
                             fit: BoxFit.scaleDown,
-                            child: Text(_wrapKeyTitle(title),
+                            child: Text(wrapKeyTitle(title),
                                 textAlign: TextAlign.center,
                                 maxLines: 3,
                                 style: const TextStyle(
@@ -1090,103 +1019,5 @@ class _HomePageState extends State<HomePage> {
       ),
     );
     if (ok == true) controller.reset();
-  }
-}
-
-/// Keeps its [child]'s state alive when scrolled off-screen in a TabBarView, so
-/// the bank swipe page and list scroll position survive a tab switch.
-class _KeepAlive extends StatefulWidget {
-  final Widget child;
-  const _KeepAlive({required this.child});
-
-  @override
-  State<_KeepAlive> createState() => _KeepAliveState();
-}
-
-class _KeepAliveState extends State<_KeepAlive>
-    with AutomaticKeepAliveClientMixin {
-  @override
-  bool get wantKeepAlive => true;
-
-  @override
-  Widget build(BuildContext context) {
-    super.build(context);
-    return widget.child;
-  }
-}
-
-/// Overlays a pulsing "now playing" glow on its [child] while [active] is true.
-/// The animation only runs while active (no idle controllers for every tile).
-class _PlayPulse extends StatefulWidget {
-  final bool active;
-  final BorderRadius radius;
-  final Widget child;
-  const _PlayPulse({
-    required this.active,
-    required this.radius,
-    required this.child,
-  });
-
-  @override
-  State<_PlayPulse> createState() => _PlayPulseState();
-}
-
-class _PlayPulseState extends State<_PlayPulse>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _c = AnimationController(
-      vsync: this, duration: const Duration(milliseconds: 600));
-
-  @override
-  void initState() {
-    super.initState();
-    if (widget.active) _c.repeat(reverse: true);
-  }
-
-  @override
-  void didUpdateWidget(_PlayPulse old) {
-    super.didUpdateWidget(old);
-    if (widget.active && !_c.isAnimating) {
-      _c.repeat(reverse: true);
-    } else if (!widget.active && _c.isAnimating) {
-      _c.stop();
-      _c.value = 0;
-    }
-  }
-
-  @override
-  void dispose() {
-    _c.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        widget.child,
-        if (widget.active)
-          Positioned.fill(
-            child: IgnorePointer(
-              child: AnimatedBuilder(
-                animation: _c,
-                builder: (_, _) {
-                  final t = Curves.easeInOut.transform(_c.value);
-                  // Subtle: a thin orange outline that gently fades in/out.
-                  return Container(
-                    decoration: BoxDecoration(
-                      borderRadius: widget.radius,
-                      border: Border.all(
-                        color: Colors.orangeAccent
-                            .withValues(alpha: 0.35 + 0.45 * t),
-                        width: 1.5,
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-      ],
-    );
   }
 }

--- a/app/lib/soundboard_controller.dart
+++ b/app/lib/soundboard_controller.dart
@@ -127,7 +127,7 @@ class SoundboardController extends ChangeNotifier {
       try {
         alive = await _ch.invokeMethod('isConnected') == true;
       } catch (_) {
-        alive = false;
+        alive = false; // a channel error means the link is not up → treat as down
       }
       if (alive) {
         if (state != ConnState.connected) {
@@ -204,7 +204,7 @@ class SoundboardController extends ChangeNotifier {
       name = (m['name'] ?? '').toString();
       address = (m['address'] ?? '').toString();
     } catch (_) {
-      return;
+      return; // corrupt stored entry → nothing valid to auto-reconnect to
     }
     if (address.isEmpty) return;
     // Don't pop a permission dialog on launch: only auto-reconnect if the user

--- a/app/lib/widgets/keep_alive.dart
+++ b/app/lib/widgets/keep_alive.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// Keeps its [child]'s state alive when scrolled off-screen in a TabBarView, so
+/// the bank swipe page and list scroll position survive a tab switch.
+class KeepAlive extends StatefulWidget {
+  final Widget child;
+  const KeepAlive({super.key, required this.child});
+
+  @override
+  State<KeepAlive> createState() => _KeepAliveState();
+}
+
+class _KeepAliveState extends State<KeepAlive>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+}

--- a/app/lib/widgets/key_title.dart
+++ b/app/lib/widgets/key_title.dart
@@ -1,0 +1,87 @@
+/// Text-wrapping for the tiny square key tiles on the soundboard grid.
+///
+/// A tile only has room for a few short lines, so a title is broken up so it
+/// still reads naturally instead of being cut mid-word. The algorithm:
+///   - a line break is allowed only *before* a non-lowercase character (so
+///     "AirHorn" splits into "Air"/"Horn" and words stay intact), or anywhere
+///     inside a single lowercase run that is itself longer than the 12-char
+///     line budget (hard split);
+///   - short fragments keep merging onto the current line until it reaches ~6
+///     characters, then it breaks at the next opportunity, which produces
+///     shorter, more even lines;
+///   - at most three lines; if text is left over, the third line is truncated
+///     with an ellipsis.
+///
+/// Pure (no widget/state dependencies) so it can be unit-tested directly and
+/// its result cached per title by the caller.
+String wrapKeyTitle(String s) {
+  bool isLower(String ch) {
+    final c = ch.codeUnitAt(0);
+    return (c >= 0x61 && c <= 0x7a) || 'äöüß'.contains(ch);
+  }
+
+  // Split into chunks; each chunk starts at a break-allowed position
+  // (start of string or any non-lowercase character).
+  final chunks = <String>[];
+  final buf = StringBuffer();
+  for (int i = 0; i < s.length; i++) {
+    final ch = s[i];
+    if (i > 0 && !isLower(ch)) {
+      chunks.add(buf.toString());
+      buf.clear();
+    }
+    buf.write(ch);
+  }
+  if (buf.isNotEmpty) chunks.add(buf.toString());
+
+  final lines = <String>[];
+  String cur = '';
+  bool more = false; // content left over after 3 lines
+  void pushCur() {
+    if (cur.isNotEmpty) {
+      lines.add(cur);
+      cur = '';
+    }
+  }
+
+  outer:
+  for (var chunk in chunks) {
+    // Hard-split a chunk that is itself longer than 12 (all lowercase run).
+    while (chunk.length > 12) {
+      pushCur();
+      if (lines.length >= 3) {
+        more = true;
+        break outer;
+      }
+      lines.add(chunk.substring(0, 12));
+      chunk = chunk.substring(12);
+    }
+    if (chunk.isEmpty) continue;
+    if (cur.isEmpty) {
+      cur = chunk;
+    } else if (cur.length < 6 && cur.length + chunk.length <= 12) {
+      // Only keep merging while the line is still short; once it reaches ~6
+      // characters, break at the next opportunity (shorter, tidier lines).
+      cur += chunk;
+    } else {
+      if (lines.length >= 3) {
+        more = true;
+        break outer;
+      }
+      lines.add(cur);
+      cur = chunk;
+    }
+  }
+  if (!more && cur.isNotEmpty) {
+    if (lines.length < 3) {
+      lines.add(cur);
+    } else {
+      more = true;
+    }
+  }
+  if (more && lines.length == 3) {
+    final last = lines[2];
+    lines[2] = '${last.length >= 12 ? last.substring(0, 11) : last}…';
+  }
+  return lines.join('\n');
+}

--- a/app/lib/widgets/play_pulse.dart
+++ b/app/lib/widgets/play_pulse.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+/// Overlays a pulsing "now playing" glow on its [child] while [active] is true.
+/// The animation controller only runs while active, so the dozens of idle key
+/// tiles don't each drive an animation every frame.
+class PlayPulse extends StatefulWidget {
+  final bool active;
+  final BorderRadius radius;
+  final Widget child;
+  const PlayPulse({
+    super.key,
+    required this.active,
+    required this.radius,
+    required this.child,
+  });
+
+  @override
+  State<PlayPulse> createState() => _PlayPulseState();
+}
+
+class _PlayPulseState extends State<PlayPulse>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _c = AnimationController(
+      vsync: this, duration: const Duration(milliseconds: 600));
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.active) _c.repeat(reverse: true);
+  }
+
+  @override
+  void didUpdateWidget(PlayPulse old) {
+    super.didUpdateWidget(old);
+    // Start/stop the loop only on a real active-state change, and reset the
+    // outline to fully faded when it stops.
+    if (widget.active && !_c.isAnimating) {
+      _c.repeat(reverse: true);
+    } else if (!widget.active && _c.isAnimating) {
+      _c.stop();
+      _c.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        widget.child,
+        if (widget.active)
+          Positioned.fill(
+            child: IgnorePointer(
+              child: AnimatedBuilder(
+                animation: _c,
+                builder: (_, _) {
+                  final t = Curves.easeInOut.transform(_c.value);
+                  // Subtle: a thin orange outline that gently fades in/out.
+                  return Container(
+                    decoration: BoxDecoration(
+                      borderRadius: widget.radius,
+                      border: Border.all(
+                        color: Colors.orangeAccent
+                            .withValues(alpha: 0.35 + 0.45 * t),
+                        width: 1.5,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/app/test/key_title_test.dart
+++ b/app/test/key_title_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:soundboard_remote/widgets/key_title.dart';
+
+void main() {
+  group('wrapKeyTitle', () {
+    test('leaves a short single-word title on one line', () {
+      expect(wrapKeyTitle('horn'), 'horn');
+    });
+
+    test('never produces a line longer than 12 characters', () {
+      for (final s in [
+        'AirHornLoudExtreme',
+        'supercalifragilistic',
+        'Bank Six Final Boss Tone',
+        'ÄußerstLangerDeutscherTitel',
+      ]) {
+        for (final line in wrapKeyTitle(s).split('\n')) {
+          expect(line.length, lessThanOrEqualTo(12), reason: 'line "$line" of "$s"');
+        }
+      }
+    });
+
+    test('never produces more than three lines', () {
+      expect(
+        wrapKeyTitle('OneTwoThreeFourFiveSixSevenEightNine').split('\n').length,
+        lessThanOrEqualTo(3),
+      );
+    });
+
+    test('truncates overflowing text with an ellipsis on the third line', () {
+      // A long all-lowercase run fills three 12-char lines and then runs out.
+      final out = wrapKeyTitle('a' * 60);
+      final lines = out.split('\n');
+      expect(lines.length, 3);
+      expect(lines.last.endsWith('…'), isTrue);
+    });
+
+    test('breaks before a capital once the current line is long enough', () {
+      // "Airhorn" (7 chars) is already past the ~6-char merge threshold, so the
+      // next capital-led word starts a new line instead of merging.
+      expect(wrapKeyTitle('AirhornBlast').split('\n'), ['Airhorn', 'Blast']);
+    });
+  });
+}

--- a/docu/CODE_REVIEW.md
+++ b/docu/CODE_REVIEW.md
@@ -1,0 +1,189 @@
+# Code-Review: Soundboard
+
+Analyse des Gesamtprojekts (ESP32-Firmware, Flutter-App, Electron-MP3-Sorter)
+nach **Performance**, **Sicherheit**, **Coding-Guidelines** und **Linting**,
+plus eine Bestandsaufnahme der Code-Kommentierung. Stand: 2026-06.
+
+> Hinweis zur Verifikation: In der Review-/Web-Umgebung waren nur **Node.js +
+> npm** verfügbar. Das Electron-Tool ist daher voll getestet (Unit-Tests,
+> ESLint, Smoke-Test). **Flutter/Dart** und **PlatformIO** fehlten, d.h.
+> Firmware und App konnten hier *nicht* kompiliert werden – Änderungen daran
+> wurden bewusst konservativ gehalten und müssen lokal mit `flutter analyze` /
+> `flutter test` bzw. `pio run` gegengeprüft werden.
+
+## Gesamteindruck
+
+Der Code ist insgesamt **überdurchschnittlich gepflegt**: durchdachte
+Architektur, gute Trennung der drei Komponenten und – anders als oft – bereits
+**dichte, sinnvolle Kommentierung** der nicht-offensichtlichen Stellen
+(Bank-/Mode-Mathematik, deferred NVS-Write, BT-Overflow-Schutz, Reconnect-Logik,
+PDF-Layout). Die wesentlichen Lücken lagen weniger bei „fehlenden Kommentaren"
+als bei **fehlendem Linting** (Electron) und einem **inkonsistenten Path-Handling**
+(Electron) sowie einer **sehr großen UI-Datei** (`app/lib/home_page.dart`).
+
+| Komponente | Performance | Sicherheit | Guidelines | Linting |
+|---|---|---|---|---|
+| Firmware (`src/main.cpp`) | gut | gut (per Design) | gut | – (kein C++-Linter eingerichtet) |
+| Flutter-App (`app/`) | gut | gut | mittel (Monolith) | flutter_lints (Default) |
+| Electron (`tools/mp3-sorter/`) | gut | mittel → **gehärtet** | gut | **fehlte → eingeführt** |
+
+---
+
+## 1. Firmware — `src/main.cpp`
+
+ESP32 / Arduino, ~330 Zeilen, eine `.cpp`. Sehr klar gegliedert und gut
+kommentiert.
+
+### Performance
+- **Keine blockierenden Delays im `loop()`**; Timing über `millis()`-Stempel.
+  Das einzige `delay(1000)` steckt in der DFPlayer-Init-Retry-Schleife in
+  `setup()` (einmalig beim Boot) – akzeptabel und kommentiert.
+- **Deferred NVS-Write** für die Lautstärke (`volumeDirty` + `VOLUME_SAVE_DELAY_MS`,
+  `main.cpp:88`) verhindert Flash-Blockaden bei schnellem +5/−5-Tippen. Sehr gut.
+- **Nicht-blockierender BT-Zeilenleser** mit fixem 8-Byte-Puffer (`main.cpp:256`)
+  – keine Heap-Fragmentierung, sauberer Overflow-Schutz.
+
+### Sicherheit
+- **Kein Bluetooth-Auth** und **Remote-Reset (`9995`)** ohne Bestätigung
+  (`main.cpp:305`). Das ist **bewusst so** (vertrauenswürdiges Umfeld, ein
+  Carbage-Run-Auto) und in `AGENTS.md` dokumentiert. Threat-Model akzeptiert;
+  als Restrisiko vermerkt (ein gekoppeltes Gerät kann Stop/Volume/Reset senden).
+- **Eingabevalidierung** ist solide: `atoi` + `if (input > 0)`, Bereichsprüfung
+  für Tracks/Volume (`main.cpp:285`, `310`), Overflow-Zeilen werden verworfen
+  statt abgeschnitten (`main.cpp:264`, `329`). Nicht existente Tracks lässt der
+  DFPlayer still fallen (kein Crash).
+
+### Coding-Guidelines
+- `keys`, `rowPins`, `colPins` (`main.cpp:57–65`) sind nicht `const`. **Bewusst
+  nicht geändert:** der `Keypad`-Konstruktor nimmt nicht-`const`-Zeiger
+  (`char*`, `byte*`), `const`-Pin-Arrays würden ohne Cast die Kompilierung
+  brechen. Niedrige Priorität.
+- Leichte Duplizierung bei den Kompat-Volume-Befehlen (`main.cpp:290–303`) –
+  vertretbar, gut lesbar; kein Umbau nötig.
+- Naming `mySerial` / `myDFPlayer` ist Arduino-üblich; rein kosmetisch.
+
+### Umgesetzt (Kommentare, null Verhaltensänderung)
+- `isPlaying()`: Unzuverlässigkeit des BUSY-Pins explizit dokumentiert und warum
+  er nur für den Stop-Toggle taugt.
+- Erläutert, warum `lastKey` nach einem Stop genullt wird.
+
+---
+
+## 2. Flutter-App — `app/`
+
+Sauberes `ChangeNotifier`-Modell. `soundboard_controller.dart` (BT-State,
+Protokoll, Reconnect-Watchdog) ist **vorbildlich kommentiert**. Native SPP-Anbindung
+in Kotlin (`MainActivity.kt`) mit korrektem Threading und Exception-Handling.
+
+### Performance
+- `ListenableBuilder` auf `[controller, AppSettings]` (`home_page.dart`), Tabs via
+  `KeepAlive`/`AutomaticKeepAliveClientMixin` am Leben gehalten – gut.
+- **Watchdog 700 ms** (`soundboard_controller.dart:125`) mit 3-s-Throttle für
+  stille Reconnects – vernünftig. *Empfehlung:* exponentielles Backoff, falls das
+  Gerät dauerhaft aus ist (Akku).
+- `wrapKeyTitle()` lief bisher pro Tile/Frame. Durch Auslagern als reine Funktion
+  ist es jetzt **cachebar** (Empfehlung: Ergebnis pro `TrackEntry` memoisieren).
+
+### Sicherheit
+- Laufzeit-Berechtigungen (`Permission.bluetoothConnect`) inkl. „dauerhaft
+  abgelehnt"-Pfad sauber behandelt (`soundboard_controller.dart:317`).
+- Nur **gekoppelte** Geräte, fixe SPP-UUID; keine Secrets in `SharedPreferences`.
+- *Empfehlung (Kotlin):* `s.connect()` ohne Timeout (`MainActivity.kt`) kann den
+  Connect-Thread bis zum OS-Timeout (~20 s) hängen lassen → `withTimeoutOrNull`.
+
+### Coding-Guidelines
+- **Hauptbefund:** `home_page.dart` war mit **1193 Zeilen** ein Monolith
+  (Grid, Controls, Dialoge, Suche, Menüs in einem `State`).
+- Vereinzelt stille `catch (_)` ohne Begründung.
+
+### Linting
+- `analysis_options.yaml` nutzte nur das Default-`flutter_lints` ohne eigene
+  Regeln.
+
+### Umgesetzt
+- **`home_page.dart` verschlankt:** die drei sicher und mechanisch
+  extrahierbaren Teile nach `lib/widgets/` ausgelagert – `wrapKeyTitle()`
+  (`key_title.dart`, jetzt unit-getestet), `KeepAlive`, `PlayPulse`.
+  Verhaltensneutral (Verbatim-Move + Referenz-Rename).
+- **Test** `test/key_title_test.dart` für die Umbruch-Invarianten.
+- **Lint-Regeln** in `analysis_options.yaml` aktiviert (single quotes, const,
+  final locals, no print, …) – stilkonform.
+- Begründungs-Kommentare an den verbleibenden `catch (_)` im Controller.
+
+### Offene Empfehlung (Follow-up mit Compiler)
+Der tiefere Split der **zustandsbehafteten** Builder-Methoden
+(`_grid`/`_key`/`_controls`/`_bankSelector`) in eigene `StatelessWidget`s wurde
+**bewusst nicht** in dieser Umgebung gemacht: er erfordert das Durchreichen von
+`controller` und etlichen Callbacks und ist ohne `flutter analyze`/Gerätetest
+nicht verifizierbar (zu hohes Regressionsrisiko für eine reine Android-App).
+
+---
+
+## 3. Electron-MP3-Sorter — `tools/mp3-sorter/`
+
+`main.js` (IPC/Dateioperationen), `preload.js` (contextBridge), `renderer/`
+(UI), `lib/naming.js` (geteilte, gut getestete Namenslogik).
+
+### Sicherheit (Electron-spezifisch)
+**Solide Grundlage:** `contextIsolation: true`, `nodeIntegration: false`
+(`main.js:91`), restriktive **CSP** (`renderer/index.html`), kein Remote-Content,
+`execFile` mit Array-Args (keine Shell-Injection), Preload als enge Whitelist.
+
+**Befund – inkonsistentes Path-Handling (behoben):** `copy-into` nutzte bereits
+`path.basename`, aber `delete-files`, `apply-renames`, `copy-to-card`, `mp3-info`
+und `file-url` verketteten den vom Renderer gelieferten Namen direkt mit dem
+Ordner. In der Praxis kommen die Namen aus dem Verzeichnis-Listing (harmlos),
+aber der Main-Prozess sollte dem Renderer nicht blind vertrauen → **Defense in
+Depth**.
+
+### Performance
+- Dateioperationen durchweg **async** (`fs/promises`), kein Sync-I/O.
+- `render()` baut das DOM komplett neu (144 Slots) – bei dieser festen Größe
+  unkritisch; dokumentiert.
+- `htmlToPdf()` startet pro Aufruf ein Offscreen-Fenster – selten/aktiv
+  ausgelöst, Pooling wäre Overkill (jetzt als Kommentar begründet).
+
+### Coding-Guidelines
+- Gut benannte IPC-Handler, `lib/naming.js` isoliert und 100 % testabgedeckt.
+- **Duplizierung:** vier nahezu identische Overlay-/Dialog-Blöcke im Renderer.
+
+### Linting
+- **Es gab kein ESLint-Setup** – die explizit angefragte Lücke.
+
+### Umgesetzt (vollständig verifiziert)
+- **`lib/safe-path.js` (`safeJoin`)** eingeführt und in *allen* betroffenen
+  IPC-Handlern angewandt; erzwingt, dass jede Dateioperation im gewählten Ordner
+  bleibt. Mit Unit-Test `test/safe-path.test.js`.
+- **ESLint Flat-Config** (`eslint.config.js`) für die drei Scopes (Node, UMD,
+  Browser), `npm run lint`-Script und Dev-Deps; einzigen Verstoß behoben
+  (ungenutzter `naming`-Import in `main.js`).
+- **`renderer/dialog.js` (`showDialog`)** extrahiert; Export-/Import-/Diff-/
+  Format-Prompts darauf umgestellt (Dedup ~80 Zeilen, konsistentes Markup).
+- Perf-Kommentar an `htmlToPdf()`.
+
+**Verifikation:** `npm test` → **16/16 grün** · `npm run lint` → **sauber** ·
+`npm run test:smoke` (xvfb) → **alle Checks grün**, inkl. „no preload/renderer
+errors" und PDF-Vorschau (bestätigt, dass `dialog.js` korrekt eingebunden ist).
+
+---
+
+## Zusammenfassung der umgesetzten Änderungen
+
+| Bereich | Änderung | Verifiziert? |
+|---|---|---|
+| Electron | `safeJoin` Path-Hardening + Test | ✅ Unit-Test |
+| Electron | ESLint Flat-Config + `lint`-Script | ✅ `npm run lint` |
+| Electron | `showDialog`-Dedup | ✅ Smoke-Test |
+| Flutter | `home_page.dart` → `widgets/` (wrapKeyTitle/KeepAlive/PlayPulse) | ⚠️ lokal `flutter test`/`analyze` |
+| Flutter | Lint-Regeln + Controller-Kommentare | ⚠️ lokal `flutter analyze` |
+| Firmware | Kommentare (BUSY-Pin, Stop-Toggle) | ⚠️ lokal `pio run` |
+
+## Empfohlene Follow-ups (nicht umgesetzt)
+1. **Flutter:** `home_page.dart` weiter aufteilen (Grid/Controls als eigene
+   Widgets) – mit Compiler/Gerätetest.
+2. **Flutter:** `wrapKeyTitle`-Ergebnis pro `TrackEntry` cachen; Reconnect-Backoff;
+   Connect-Timeout im Kotlin-Channel.
+3. **Firmware:** optional ESP-seitig die Befehls-Annahme härten (z.B. Reset nur
+   nach Bestätigungs-Sequenz), falls das Threat-Model strenger wird.
+4. **CI:** GitHub-Action, die zumindest `npm test` + `npm run lint` (Electron)
+   und – mit Flutter-Setup – `flutter analyze`/`flutter test` fährt.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,10 @@ DFPlayerMini_Fast myDFPlayer;
 
 // Read playback state from the BUSY pin (instant) instead of a serial query.
 // BUSY is LOW while a track is playing, HIGH when idle.
+// NOTE: this DFPlayer's BUSY signal is unreliable — it often reads idle ~1 s
+// into a track and flickers. So we only use it for the momentary same-key
+// "stop" toggle below (a missed read just means the toggle no-ops), never as a
+// trustworthy "is something playing" indicator.
 bool isPlaying()
 {
   return digitalRead(BUSY_PIN) == LOW;
@@ -162,7 +166,7 @@ void keypadEvent(KeypadEvent key)
     if (isPlaying() && lastKey == key)
     { // same key pressed again → stop (toggle)
       myDFPlayer.stop();
-      lastKey = 0;
+      lastKey = 0; // clear it so the next press of this key plays again, not stops
     }
     else
     {

--- a/tools/mp3-sorter/eslint.config.js
+++ b/tools/mp3-sorter/eslint.config.js
@@ -1,0 +1,43 @@
+// ESLint flat config (ESLint v9+). Three environments live in this project:
+//   - Electron main / preload / tests  -> Node (CommonJS)
+//   - lib/*.js                          -> UMD modules used in BOTH Node and the
+//                                          browser, so they need both global sets
+//   - renderer/*.js                     -> browser, classic <script> scope, plus
+//                                          the globals injected by naming.js,
+//                                          dialog.js and the preload `api` bridge
+const js = require("@eslint/js");
+const globals = require("globals");
+
+module.exports = [
+  { ignores: ["node_modules/**", "dist/**"] },
+  js.configs.recommended,
+  {
+    files: ["main.js", "preload.js", "test/**/*.js", "eslint.config.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "commonjs",
+      globals: { ...globals.node },
+    },
+  },
+  {
+    // UMD helpers: detect their environment at runtime, so allow both.
+    files: ["lib/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "commonjs",
+      globals: { ...globals.node, ...globals.browser },
+    },
+  },
+  {
+    // Browser, classic <script> scope. The cross-file globals (naming, api,
+    // showDialog) are declared per-file via `/* global ... */` directives, so we
+    // don't predeclare them here (that would clash with dialog.js, which *defines*
+    // showDialog).
+    files: ["renderer/**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: { ...globals.browser },
+    },
+  },
+];

--- a/tools/mp3-sorter/lib/safe-path.js
+++ b/tools/mp3-sorter/lib/safe-path.js
@@ -1,0 +1,35 @@
+// Defence-in-depth path helper for IPC handlers.
+//
+// Every file operation triggered from the renderer joins a folder (chosen by the
+// user via the OS dialog) with a *filename* that the renderer supplies. Those
+// filenames are normally plain basenames taken from a directory listing, so they
+// are harmless. But the main process must not trust the renderer blindly: a bug
+// (or a compromised renderer) could pass a crafted name like "../../secret" and
+// make us read/delete/overwrite files outside the chosen folder.
+//
+// safeJoin() collapses the name to its basename and asserts the result really is
+// a direct child of `folder`, throwing otherwise. Using it everywhere keeps the
+// blast radius of any file operation limited to the folder the user picked.
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory(require("path"));
+  } else {
+    root.safePath = factory(root.path);
+  }
+})(typeof self !== "undefined" ? self : this, function (path) {
+  // Join `name` onto `folder`, guaranteeing the result is a file directly inside
+  // `folder` (no "../" escape, no nested subdirectory). Throws on violation.
+  function safeJoin(folder, name) {
+    if (typeof folder !== "string" || !folder) throw new Error("invalid folder");
+    if (typeof name !== "string" || !name) throw new Error("invalid name");
+    // basename() drops any directory component, so "../x" and "a/b" become "x"/"b".
+    const full = path.resolve(folder, path.basename(name));
+    // After resolving, the parent directory must be exactly the chosen folder.
+    if (path.dirname(full) !== path.resolve(folder)) {
+      throw new Error(`unsafe path: ${name}`);
+    }
+    return full;
+  }
+
+  return { safeJoin };
+});

--- a/tools/mp3-sorter/main.js
+++ b/tools/mp3-sorter/main.js
@@ -6,7 +6,7 @@ const { execFile } = require("child_process");
 const { promisify } = require("util");
 const { pathToFileURL } = require("url");
 const { existsSync } = require("fs");
-const naming = require("./lib/naming");
+const { safeJoin } = require("./lib/safe-path");
 const keyColors = require("./lib/key-colors.json");
 const mm = require("music-metadata");
 
@@ -122,8 +122,10 @@ ipcMain.on("get-colors", (e) => {
 });
 
 // --- IPC: cross-platform file:// URL for a folder + filename ---
+// safeJoin keeps `name` confined to `folder` (the renderer-supplied name is
+// trusted only as a basename, never as a path that could escape the folder).
 ipcMain.handle("file-url", (_e, folder, name) =>
-  pathToFileURL(path.join(folder, name)).href
+  pathToFileURL(safeJoin(folder, name)).href
 );
 
 // --- IPC: reveal the current folder in the OS file manager ---
@@ -186,7 +188,7 @@ ipcMain.handle("copy-into", async (_e, folder, paths) => {
   let copied = 0;
   for (const p of paths) {
     if (!p || !p.toLowerCase().endsWith(".mp3")) continue;
-    const dest = path.join(folder, path.basename(p));
+    const dest = safeJoin(folder, p); // confine the copy target to `folder`
     if (path.resolve(p) === path.resolve(dest)) continue; // already there
     try {
       await fs.copyFile(p, dest);
@@ -220,6 +222,9 @@ ipcMain.handle("save-draft", async (_e, folder, state) => {
 });
 
 // Render an HTML string to an A4-landscape PDF buffer (offscreen).
+// A fresh hidden window is spun up per call. That is a few hundred ms of
+// Chromium startup, but PDF export/preview is a rare, user-triggered action, so
+// pooling a long-lived window would add complexity for no perceptible gain.
 async function htmlToPdf(html) {
   const win = new BrowserWindow({ show: false });
   try {
@@ -379,10 +384,12 @@ ipcMain.handle("apply-renames", async (_e, folder, plan) => {
   const tmpSuffix = `.mp3sorter.tmp.${process.pid}`;
 
   try {
-    // Phase 1: move every changing file to a unique temp name.
+    // Phase 1: move every changing file to a unique temp name. safeJoin guards
+    // the renderer-supplied `from`/`to`; the temp name is generated here, so a
+    // plain join is fine for it.
     for (let i = 0; i < toRename.length; i++) {
       await fs.rename(
-        path.join(folder, toRename[i].from),
+        safeJoin(folder, toRename[i].from),
         path.join(folder, `__${i}${tmpSuffix}`)
       );
     }
@@ -390,7 +397,7 @@ ipcMain.handle("apply-renames", async (_e, folder, plan) => {
     for (let i = 0; i < toRename.length; i++) {
       await fs.rename(
         path.join(folder, `__${i}${tmpSuffix}`),
-        path.join(folder, toRename[i].to)
+        safeJoin(folder, toRename[i].to)
       );
     }
   } catch (err) {
@@ -483,7 +490,7 @@ ipcMain.handle("delete-files", async (_e, folder, names) => {
   const failed = [];
   for (const name of names) {
     try {
-      await fs.unlink(path.join(folder, name));
+      await fs.unlink(safeJoin(folder, name)); // never delete outside `folder`
       deleted.push(name);
     } catch (err) {
       failed.push({ name, error: String(err && err.message ? err.message : err) });
@@ -495,7 +502,7 @@ ipcMain.handle("delete-files", async (_e, folder, names) => {
 // --- IPC: read MP3 duration and bitrate ---
 ipcMain.handle("mp3-info", async (_e, folder, name) => {
   try {
-    const meta = await mm.parseFile(path.join(folder, name), { duration: true });
+    const meta = await mm.parseFile(safeJoin(folder, name), { duration: true });
     const dur = meta.format.duration || 0;
     const br = meta.format.bitrate ? Math.round(meta.format.bitrate / 1000) : null;
     const mins = Math.floor(dur / 60);
@@ -535,9 +542,10 @@ ipcMain.handle("copy-to-card", async (event, srcFolder, targetDir, items, wipeRo
     let copied = 0;
     for (const it of items) {
       if (copyCancelled) return { ok: false, cancelled: true, copied };
+      // Confine both ends: read from srcFolder, write into targetDir, no escape.
       await fs.copyFile(
-        path.join(srcFolder, it.orig),
-        path.join(targetDir, it.name)
+        safeJoin(srcFolder, it.orig),
+        safeJoin(targetDir, it.name)
       );
       copied++;
       event.sender.send("copy-progress", {

--- a/tools/mp3-sorter/package-lock.json
+++ b/tools/mp3-sorter/package-lock.json
@@ -12,9 +12,12 @@
         "music-metadata": "^7.14.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.0.0",
         "electron": "^33.0.0",
         "electron-builder": "^25.0.0",
-        "electron-reloader": "^1.2.3"
+        "electron-reloader": "^1.2.3",
+        "eslint": "^9.0.0",
+        "globals": "^15.0.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -403,12 +406,297 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -709,6 +997,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
@@ -723,6 +1018,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -828,6 +1130,29 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -1564,6 +1889,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2030,6 +2365,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -2653,12 +2995,209 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -2732,6 +3271,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2740,6 +3286,19 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-type": {
@@ -2828,6 +3387,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3129,6 +3709,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -3389,6 +3982,33 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3643,6 +4263,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3741,6 +4368,20 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3795,6 +4436,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
@@ -4177,6 +4825,13 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -4376,6 +5031,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -4464,6 +5137,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -4597,6 +5283,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/process": {
@@ -4856,6 +5552,16 @@
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
@@ -5264,6 +5970,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strtok3": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
@@ -5473,6 +6192,19 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -5618,6 +6350,16 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/tools/mp3-sorter/package.json
+++ b/tools/mp3-sorter/package.json
@@ -7,14 +7,18 @@
     "start": "electron .",
     "test": "node --test \"test/**/*.test.js\"",
     "test:smoke": "electron test/smoke.js",
+    "lint": "eslint .",
     "dist": "electron-builder"
   },
   "author": "Ronny Elflein",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "electron": "^33.0.0",
     "electron-builder": "^25.0.0",
-    "electron-reloader": "^1.2.3"
+    "electron-reloader": "^1.2.3",
+    "eslint": "^9.0.0",
+    "globals": "^15.0.0"
   },
   "build": {
     "appId": "de.11lein.mp3sorter",

--- a/tools/mp3-sorter/renderer/dialog.js
+++ b/tools/mp3-sorter/renderer/dialog.js
@@ -1,0 +1,53 @@
+/* exported showDialog */
+// Generic modal dialog, loaded as a plain <script> before renderer.js (same
+// pattern as naming.js). It replaces the ~4 near-identical hand-rolled overlay
+// blocks the renderer used to carry (export/import/diff/format prompts), each of
+// which built an `.overlay > .dialog` node, wired button clicks and resolved a
+// Promise. Centralising that here removes the duplication and keeps the markup
+// (and thus the styling) consistent across every dialog.
+//
+// Usage:
+//   const choice = await showDialog({
+//     title: "Titel",                 // HTML (escape yourself if it's user data)
+//     html: "<p class='muted'>…</p>",  // optional body markup
+//     wide: false,                     // use the wider .dialog layout
+//     buttons: [
+//       { label: "Abbrechen", kind: "link", value: null },
+//       { label: "OK", kind: "primary", value: (root) => readInputs(root) },
+//     ],
+//   });
+// The returned Promise resolves to the clicked button's `value`. If `value` is a
+// function it is called with the dialog root element (handy for reading checkbox
+// or input state at click time). A disabled button cannot be clicked.
+function showDialog({ title, html = "", wide = false, buttons = [] }) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "overlay";
+    const btnHtml = buttons
+      .map((b, i) => {
+        const cls = b.kind ? ` ${b.kind}` : "";
+        const dis = b.disabled ? " disabled" : "";
+        return `<button data-dlg="${i}" class="dlg-btn${cls}"${dis}>${b.label}</button>`;
+      })
+      .join("");
+    overlay.innerHTML =
+      `<div class="dialog${wide ? " wide" : ""}">` +
+      `<h3>${title}</h3>${html}` +
+      `<div class="dialog-buttons">${btnHtml}</div>` +
+      `</div>`;
+    document.body.appendChild(overlay);
+
+    const done = (v) => {
+      overlay.remove();
+      resolve(v);
+    };
+    buttons.forEach((b, i) => {
+      if (b.disabled) return;
+      overlay.querySelector(`[data-dlg="${i}"]`).onclick = () =>
+        done(typeof b.value === "function" ? b.value(overlay) : b.value);
+    });
+  });
+}
+
+// Expose globally for renderer.js (classic script, no module system here).
+window.showDialog = showDialog;

--- a/tools/mp3-sorter/renderer/index.html
+++ b/tools/mp3-sorter/renderer/index.html
@@ -65,6 +65,7 @@
     </div>
 
     <script src="../lib/naming.js"></script>
+    <script src="dialog.js"></script>
     <script src="renderer.js"></script>
   </body>
 </html>

--- a/tools/mp3-sorter/renderer/renderer.js
+++ b/tools/mp3-sorter/renderer/renderer.js
@@ -1,4 +1,4 @@
-/* global naming, api */
+/* global naming, api, showDialog */
 const { BANK_SIZE, NUM_BANKS, TOTAL_SLOTS, prefixForSlot, pad4 } = naming;
 
 // Model: 144 slots (gaps allowed) + a parked list of unprefixed files.
@@ -621,35 +621,28 @@ function listFileName() {
 // Ask where the exported list should go (any combination): app assets (for the
 // next build), straight onto the phone via ADB (no build), and/or a file.
 function listExportPrompt() {
-  return new Promise((resolve) => {
-    const overlay = document.createElement("div");
-    overlay.className = "overlay";
-    overlay.innerHTML = `
-      <div class="dialog">
-        <h3>Liste exportieren</h3>
-        <p class="muted">Ziel(e) wählen:</p>
-        <div class="opt-col">
-          <label class="cb"><input type="checkbox" id="le-app" checked> 📱 App-Verzeichnis (nächster App-Build)</label>
-          <label class="cb"><input type="checkbox" id="le-adb"> 📲 Aufs Handy (ADB, ohne Build)</label>
-          <label class="cb"><input type="checkbox" id="le-file"> 💾 In Datei speichern…</label>
-        </div>
-        <div class="dialog-buttons">
-          <button id="le-cancel" class="link">Abbrechen</button>
-          <button id="le-ok" class="primary">Exportieren</button>
-        </div>
-      </div>`;
-    document.body.appendChild(overlay);
-    const done = (v) => {
-      overlay.remove();
-      resolve(v);
-    };
-    overlay.querySelector("#le-cancel").onclick = () => done(null);
-    overlay.querySelector("#le-ok").onclick = () =>
-      done({
-        app: overlay.querySelector("#le-app").checked,
-        adb: overlay.querySelector("#le-adb").checked,
-        file: overlay.querySelector("#le-file").checked,
-      });
+  return showDialog({
+    title: "Liste exportieren",
+    html: `
+      <p class="muted">Ziel(e) wählen:</p>
+      <div class="opt-col">
+        <label class="cb"><input type="checkbox" id="le-app" checked> 📱 App-Verzeichnis (nächster App-Build)</label>
+        <label class="cb"><input type="checkbox" id="le-adb"> 📲 Aufs Handy (ADB, ohne Build)</label>
+        <label class="cb"><input type="checkbox" id="le-file"> 💾 In Datei speichern…</label>
+      </div>`,
+    buttons: [
+      { label: "Abbrechen", kind: "link", value: null },
+      {
+        label: "Exportieren",
+        kind: "primary",
+        // Read the checkbox state at click time and return the chosen targets.
+        value: (root) => ({
+          app: root.querySelector("#le-app").checked,
+          adb: root.querySelector("#le-adb").checked,
+          file: root.querySelector("#le-file").checked,
+        }),
+      },
+    ],
   });
 }
 
@@ -729,61 +722,39 @@ function computeImportDiff(tracks) {
 
 // Ask whether the list to import comes from a file or from the phone (ADB).
 function listImportPrompt() {
-  return new Promise((resolve) => {
-    const overlay = document.createElement("div");
-    overlay.className = "overlay";
-    overlay.innerHTML = `
-      <div class="dialog">
-        <h3>Liste importieren</h3>
-        <p class="muted">Quelle wählen:</p>
-        <div class="dialog-buttons">
-          <button id="li-file" class="primary">📁 Aus Datei</button>
-          <button id="li-adb">📲 Vom Handy (ADB)</button>
-        </div>
-        <button id="li-cancel" class="link">Abbrechen</button>
-      </div>`;
-    document.body.appendChild(overlay);
-    const done = (v) => {
-      overlay.remove();
-      resolve(v);
-    };
-    overlay.querySelector("#li-file").onclick = () => done("file");
-    overlay.querySelector("#li-adb").onclick = () => done("adb");
-    overlay.querySelector("#li-cancel").onclick = () => done(null);
+  return showDialog({
+    title: "Liste importieren",
+    html: `<p class="muted">Quelle wählen:</p>`,
+    buttons: [
+      { label: "📁 Aus Datei", kind: "primary", value: "file" },
+      { label: "📲 Vom Handy (ADB)", value: "adb" },
+      { label: "Abbrechen", kind: "link", value: null },
+    ],
   });
 }
 
 // Diff confirmation before importing (old → new names).
 function importDiffPrompt(diff) {
-  return new Promise((resolve) => {
-    const rows = diff.changes
-      .map(
-        (c) =>
-          `<div class="rn-row"><span class="rn-old">${escapeHtml(String(c.n))} · ${escapeHtml(c.from)}</span>` +
-          `<span class="rn-arrow">→</span><span class="rn-new">${escapeHtml(c.to)}</span></div>`
-      )
-      .join("");
-    const overlay = document.createElement("div");
-    overlay.className = "overlay";
-    overlay.innerHTML = `
-      <div class="dialog wide">
-        <h3>Liste importieren – Änderungen</h3>
-        <p class="muted">${diff.changes.length} Umbenennung(en)${
-          diff.missing ? ` · ${diff.missing} ohne passende Datei` : ""
-        }</p>
-        <div class="rn-preview">${rows || '<p class="muted">Keine Änderungen.</p>'}</div>
-        <div class="dialog-buttons">
-          <button id="id-cancel" class="link">Abbrechen</button>
-          <button id="id-ok" class="primary"${diff.changes.length ? "" : " disabled"}>Übernehmen</button>
-        </div>
-      </div>`;
-    document.body.appendChild(overlay);
-    const done = (v) => {
-      overlay.remove();
-      resolve(v);
-    };
-    overlay.querySelector("#id-cancel").onclick = () => done(false);
-    overlay.querySelector("#id-ok").onclick = () => done(true);
+  const rows = diff.changes
+    .map(
+      (c) =>
+        `<div class="rn-row"><span class="rn-old">${escapeHtml(String(c.n))} · ${escapeHtml(c.from)}</span>` +
+        `<span class="rn-arrow">→</span><span class="rn-new">${escapeHtml(c.to)}</span></div>`
+    )
+    .join("");
+  return showDialog({
+    title: "Liste importieren – Änderungen",
+    wide: true,
+    html:
+      `<p class="muted">${diff.changes.length} Umbenennung(en)${
+        diff.missing ? ` · ${diff.missing} ohne passende Datei` : ""
+      }</p>` +
+      `<div class="rn-preview">${rows || '<p class="muted">Keine Änderungen.</p>'}</div>`,
+    buttons: [
+      { label: "Abbrechen", kind: "link", value: false },
+      // Nothing to apply when the diff is empty → disable the confirm button.
+      { label: "Übernehmen", kind: "primary", value: true, disabled: diff.changes.length === 0 },
+    ],
   });
 }
 
@@ -989,28 +960,15 @@ async function openSdDialog() {
 }
 
 function sdFormatPrompt(d) {
-  return new Promise((resolve) => {
-    const overlay = document.createElement("div");
-    overlay.className = "overlay";
-    overlay.innerHTML = `
-      <div class="dialog">
-        <h3>SD-Karte „${escapeHtml(d.label || d.mount)}"</h3>
-        <p>Vor dem Kopieren formatieren? <b>Alle Daten auf der Karte gehen verloren.</b>
-        Formatieren kann Administratorrechte erfordern.</p>
-        <div class="dialog-buttons">
-          <button id="f-yes" class="danger">Formatieren & Kopieren</button>
-          <button id="f-no" class="primary">Nur kopieren</button>
-        </div>
-        <button id="f-cancel" class="link">Abbrechen</button>
-      </div>`;
-    document.body.appendChild(overlay);
-    const done = (v) => {
-      overlay.remove();
-      resolve(v);
-    };
-    overlay.querySelector("#f-yes").onclick = () => done("format");
-    overlay.querySelector("#f-no").onclick = () => done("copy");
-    overlay.querySelector("#f-cancel").onclick = () => done("cancel");
+  return showDialog({
+    title: `SD-Karte „${escapeHtml(d.label || d.mount)}"`,
+    html: `<p>Vor dem Kopieren formatieren? <b>Alle Daten auf der Karte gehen verloren.</b>
+      Formatieren kann Administratorrechte erfordern.</p>`,
+    buttons: [
+      { label: "Formatieren & Kopieren", kind: "danger", value: "format" },
+      { label: "Nur kopieren", kind: "primary", value: "copy" },
+      { label: "Abbrechen", kind: "link", value: "cancel" },
+    ],
   });
 }
 

--- a/tools/mp3-sorter/test/safe-path.test.js
+++ b/tools/mp3-sorter/test/safe-path.test.js
@@ -1,0 +1,31 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { safeJoin } = require("../lib/safe-path");
+
+const FOLDER = path.resolve("/music");
+
+test("safeJoin returns a direct child of the folder", () => {
+  assert.equal(safeJoin(FOLDER, "0101_horn.mp3"), path.join(FOLDER, "0101_horn.mp3"));
+});
+
+test("safeJoin strips directory components to the basename", () => {
+  // A nested path collapses to its file name inside the folder (no subdir escape).
+  assert.equal(safeJoin(FOLDER, "sub/dir/x.mp3"), path.join(FOLDER, "x.mp3"));
+});
+
+test("safeJoin neutralises ../ traversal (collapses to basename in-folder)", () => {
+  // "../../etc/passwd" -> basename "passwd" -> stays inside the folder.
+  assert.equal(safeJoin(FOLDER, "../../etc/passwd"), path.join(FOLDER, "passwd"));
+});
+
+test("safeJoin rejects names that resolve to nothing in-folder", () => {
+  assert.throws(() => safeJoin(FOLDER, ".."), /unsafe path|invalid/);
+  assert.throws(() => safeJoin(FOLDER, "."), /unsafe path|invalid/);
+});
+
+test("safeJoin rejects empty/invalid inputs", () => {
+  assert.throws(() => safeJoin("", "x.mp3"), /invalid folder/);
+  assert.throws(() => safeJoin(FOLDER, ""), /invalid name/);
+  assert.throws(() => safeJoin(FOLDER, null), /invalid name/);
+});


### PR DESCRIPTION
- Introduce lib/safe-path.js (safeJoin) and apply it to every IPC handler that
  joins a renderer-supplied filename onto a folder (file-url, copy-into,
  apply-renames, delete-files, mp3-info, copy-to-card) so file operations can
  never escape the chosen folder. Add safe-path unit tests.
- Add an ESLint flat config (eslint.config.js) covering the Node, UMD and
  browser scopes, a "lint" npm script, and the eslint/globals dev deps; fix the
  one violation it found (unused naming import in main.js).
- Extract the repeated dialog overlay boilerplate into renderer/dialog.js
  (showDialog) and convert the export/import/diff/format prompts to it.
- Document the per-call offscreen PDF window rationale.

Verified: npm test (16 passing), npm run lint (clean), smoke test (passing).